### PR TITLE
bug: fix empty array issue

### DIFF
--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -136,7 +136,7 @@ func FormatProofForSolidity(accountTreeRoot []byte, proof *rewardsCoordinator.IR
 }
 
 func convertTokenLeavesToSolidityLeaves(tokenLeaves []rewardsCoordinator.IRewardsCoordinatorTokenTreeMerkleLeaf) []IRewardsCoordinatorTokenTreeMerkleLeafStrings {
-	leaves := make([]IRewardsCoordinatorTokenTreeMerkleLeafStrings, len(tokenLeaves))
+	leaves := make([]IRewardsCoordinatorTokenTreeMerkleLeafStrings, 0)
 	for _, leaf := range tokenLeaves {
 		leaves = append(leaves, IRewardsCoordinatorTokenTreeMerkleLeafStrings{
 			Token:              leaf.Token,


### PR DESCRIPTION
Fix bug where empty allocation leads to extra array element.

Bug
```
"tokenLeaves": [
    {
      "token": "0x0000000000000000000000000000000000000000",
      "cumulativeEarnings": null
    },
    {
      "token": "0x554c393923c753d146aa34608523ad7946b61662",
      "cumulativeEarnings": 132817613607819840
    }
  ]
```

After
```
"tokenLeaves": [
    {
      "token": "0x554c393923c753d146aa34608523ad7946b61662",
      "cumulativeEarnings": 132817613607819840
    }
  ]
```